### PR TITLE
Use correct argument order when invoking httpclient.NewAuthenticatedClient

### DIFF
--- a/mittwaldv2/client_opt_auth.go
+++ b/mittwaldv2/client_opt_auth.go
@@ -19,7 +19,7 @@ const apiTokenHeader = "X-Access-Token"
 // The access token needs to be obtained ahead-of-time.
 func WithAccessToken(token string) ClientOption {
 	return func(_ context.Context, inner httpclient.RequestRunner) (httpclient.RequestRunner, error) {
-		return httpclient.NewAuthenticatedClient(inner, apiTokenHeader, token), nil
+		return httpclient.NewAuthenticatedClient(inner, token, apiTokenHeader), nil
 	}
 }
 


### PR DESCRIPTION
The `WithAccessToken` client option uses the wrong argument order when creating the underlying httpclient. This results in the following error message, since it confuses the header name `X-Access-Token` and its value:

```
panic: Get "https://api.mittwald.de/v2/projects": net/http: invalid header field name "[*** MW token redacted ***]"
```

This PR fixes that.